### PR TITLE
adds first cut of infra for lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 node_modules
+
+.terragrunt-cache

--- a/.infra/.tool-versions
+++ b/.infra/.tool-versions
@@ -1,0 +1,2 @@
+terraform 1.3.4
+terragrunt 0.40.1

--- a/.infra/README.md
+++ b/.infra/README.md
@@ -1,0 +1,74 @@
+# HYPRActive Staff Service IaC
+
+## Getting started
+
+One time steps:
+
+- [Provision your AWS IAM user](https://github.com/hyprnz/aws-platform-live/blob/main/infosec/ap-southeast-2/prod/iam/README.md)
+  - If you are on the DevOps team or intend to be running Terraform, you will need to be added to the infra admins
+    groups
+- Install and set up the [required tools](https://github.com/hyprnz/aws-platform-live/blob/main/docs/tooling.md)
+
+In this repo:
+
+```shell
+cd .infra
+asdf install
+```
+
+### To run your terraform:
+
+```shell
+# Navigate to the directory of the resource you want to provision, e.g.
+cd infosec/ap-southeast-2/prod/hypractive-staff-service-artifactory
+
+# ***************
+# * This is using the `hypr-nonprod-infraadmin` profile - use the
+# * hypr-prod-infraadmin for provisioning prod environment!
+# ***************
+
+# One time - prepare the working directory
+aws-vault exec hypr-nonprod-infraadmin -- terragrunt init
+
+# Show the changes between the TF configuration and what is currently in TF state
+aws-vault exec hypr-nonprod-infraadmin -- terragrunt plan
+
+# Create/update the infrastructure!
+aws-vault exec hypr-nonprod-infraadmin -- terragrunt apply
+```
+
+### Understanding the code
+
+Within the `.infra` folder, you'll find a `.tool-versions` file. This defines the exact Terraform and Terragrunt
+versions used in the project for [asdf](https://asdf-vm.com/guide/introduction.html#how-it-works), which we use to
+manage versions. Terraform remote state has strict rules around versions, so ensuring you have the correct version and
+avoid accidental upgrades is important.
+
+You'll also find a `terragrunt.hcl` in the `.infra` folder. This the base Terragrunt config for the project, defining
+any parameters that apply to all the Terragrunt configurations in child folders. It is merged into child
+`terragrunt.hcl` configs via an `include` block.
+
+The file path follows `[account]/[region]/[environment]/[resource]/terragrunt.hcl`, which is used as the unique name for
+the resource for our Terraform state:
+
+- `account`: Maps to the IAM account alias in AWS. Read more about our different accounts and what we use them for
+  [here](https://github.com/hyprnz/aws-platform-live#aws-account-design).
+- `region`: AWS region that the resource will be provisioned in. For now, everything should be living in
+  `ap-southeast-2`.
+- `environment`: For now, we'll use either `uat` or `prod`.
+- `resource`: e.g. service name.
+
+We are making use of Terraform modules, which help to reduce complexity and repetition in our TF code. This repo
+currently implements a lambda application module from
+[hypr-terraform-modules](https://github.com/hyprnz/hypr-terraform-modules), which is our organisational abstraction over
+HYPR's [terraform-aws-lambda-application-module](https://github.com/hyprnz/terraform-aws-lambda-application-module). You
+can get some additional context from the READMEs in the
+[hypr-terraform-modules](https://github.com/hyprnz/hypr-terraform-modules) and
+[aws-platform-live](https://github.com/hyprnz/aws-platform-live) repos.
+
+> **Definition!** You'll see we are using an `artifactory` for our lambda application. Artifactory is an abbreviation of
+> artifact repository. While we store and manage our source code in repositories in GitHub, an artifactory is a
+> repository for built code (binaries, often referred to as artifacts.) We use the artifactory to support Continuous
+> Integration - we build the source code once and store it in the artifactory. From there, the same artifact can be
+> called and deployed into all of our environments, so we can have confidence that working code in UAT will be the same
+> working code in production.

--- a/.infra/empty.yaml
+++ b/.infra/empty.yaml
@@ -1,0 +1,4 @@
+# This is intentionally empty object. This YAML file is used as a catch all to return an empty map when expected yaml
+# vars do not exist. Note that this file can not be completely empty because terragrunt's yamldecode function expects an
+# object, and it doesn't treat empty files as an empty object (you get a syntax error).
+{}

--- a/.infra/hypractive.yaml
+++ b/.infra/hypractive.yaml
@@ -1,0 +1,8 @@
+terraform_state_bucket: admin-terraform-state.hypr.nz
+terraform_state_bucket_region: ap-southeast-2
+
+# TODO - configure lambda defaults here - e.g.
+# alias_name: hypractive-clockify-api-client-latest
+# application_name: hypractive-clockify-api-client
+# service_target_group_name: "hypractive-clockify-api-client-target-group"
+# service_target_group_path: "hypractive-clockify-api-client-target-group-path"

--- a/.infra/infosec/account.yaml
+++ b/.infra/infosec/account.yaml
@@ -1,0 +1,1 @@
+aws_account_number: 107484634957

--- a/.infra/infosec/ap-southeast-2/prod/environment.yaml
+++ b/.infra/infosec/ap-southeast-2/prod/environment.yaml
@@ -1,0 +1,1 @@
+environment: prod

--- a/.infra/infosec/ap-southeast-2/prod/hypractive-clockify-api-client-artifactory/.terraform.lock.hcl
+++ b/.infra/infosec/ap-southeast-2/prod/hypractive-clockify-api-client-artifactory/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.75.2"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:lcSLAmkNM1FvNhqAEbh2oTZRqF37HKRh1Di8LvssYBY=",
+    "h1:x0gluX9ZKEmz+JJW3Ut5GgWDFOq/lhs2vkqJ+xt57zs=",
+    "zh:0e75fb14ec42d69bc46461dd54016bb2487d38da324222cec20863918b8954c4",
+    "zh:30831a1fe29f005d8b809250b43d09522288db45d474c9d238b26f40bdca2388",
+    "zh:36163d625ab2999c9cd31ef2475d978f9f033a8dfa0d585f1665f2d6492fac4b",
+    "zh:48ec39685541e4ddd8ddd196e2cfb72516b87f471d86ac3892bc11f83c573199",
+    "zh:707b9c8775efd6962b6226d914ab25f308013bba1f68953daa77adca99ff6807",
+    "zh:72bd9f4609a827afa366c6f119c7dec7d73a35d712dad1457c0497d87bf8d160",
+    "zh:930e3ae3d0cb152e17ee5a8aee5cb47f7613d6421bc7c22e7f50c19da484a100",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a19bf49b80101a0f0272b994153eeff8f8c206ecc592707bfbce7563355b6882",
+    "zh:a34b5d2bbaf52285b0c9a8df6258f4789f4d927ff777e126bdc77e7887abbeaa",
+    "zh:caad6fd5e79eae33e6d74e38c3b15c28a5482f2a1a8ca46cc1ee70089de61adb",
+    "zh:f2eae988635030de9a088f8058fbcd91e2014a8312a48b16bfd09a9d69d9d6f7",
+  ]
+}

--- a/.infra/infosec/ap-southeast-2/prod/hypractive-clockify-api-client-artifactory/readme.md
+++ b/.infra/infosec/ap-southeast-2/prod/hypractive-clockify-api-client-artifactory/readme.md
@@ -1,0 +1,15 @@
+# Artifactory S3 bucket provisioning
+
+The S3 bucket's name is `hypractive-clockify-api-client-artifactory`.
+
+## Create the S3 bucket
+
+```terragrunt
+aws-vault exec hypr-infosec-infraadmin -- terragrunt apply
+```
+
+## Destroy the S3 bucket
+
+```terragrunt
+aws-vault exec hypr-infosec-infraadmin -- terragrunt destroy
+```

--- a/.infra/infosec/ap-southeast-2/prod/hypractive-clockify-api-client-artifactory/terragrunt.hcl
+++ b/.infra/infosec/ap-southeast-2/prod/hypractive-clockify-api-client-artifactory/terragrunt.hcl
@@ -1,0 +1,24 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform that supports locking and enforces best
+# practices: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
+
+
+
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+terraform {
+  source = "git@github.com:hyprnz/hypr-terraform-modules.git//lambda/artifactory?ref=v0.4.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = "${find_in_parent_folders()}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+# ---------------------------------------------------------------------------------------------------------------------
+inputs = {}

--- a/.infra/infosec/ap-southeast-2/region.yaml
+++ b/.infra/infosec/ap-southeast-2/region.yaml
@@ -1,0 +1,1 @@
+aws_region: ap-southeast-2

--- a/.infra/non-prod/account.yaml
+++ b/.infra/non-prod/account.yaml
@@ -1,0 +1,1 @@
+aws_account_number: 277544569108

--- a/.infra/non-prod/ap-southeast-2/region.yaml
+++ b/.infra/non-prod/ap-southeast-2/region.yaml
@@ -1,0 +1,1 @@
+aws_region: ap-southeast-2

--- a/.infra/non-prod/ap-southeast-2/uat/environment.yaml
+++ b/.infra/non-prod/ap-southeast-2/uat/environment.yaml
@@ -1,0 +1,1 @@
+environment: uat

--- a/.infra/non-prod/ap-southeast-2/uat/hypractive-clockify-api-client/.terraform.lock.hcl
+++ b/.infra/non-prod/ap-southeast-2/uat/hypractive-clockify-api-client/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.75.2"
+  constraints = ">= 3.38.0"
+  hashes = [
+    "h1:lcSLAmkNM1FvNhqAEbh2oTZRqF37HKRh1Di8LvssYBY=",
+    "h1:x0gluX9ZKEmz+JJW3Ut5GgWDFOq/lhs2vkqJ+xt57zs=",
+    "zh:0e75fb14ec42d69bc46461dd54016bb2487d38da324222cec20863918b8954c4",
+    "zh:30831a1fe29f005d8b809250b43d09522288db45d474c9d238b26f40bdca2388",
+    "zh:36163d625ab2999c9cd31ef2475d978f9f033a8dfa0d585f1665f2d6492fac4b",
+    "zh:48ec39685541e4ddd8ddd196e2cfb72516b87f471d86ac3892bc11f83c573199",
+    "zh:707b9c8775efd6962b6226d914ab25f308013bba1f68953daa77adca99ff6807",
+    "zh:72bd9f4609a827afa366c6f119c7dec7d73a35d712dad1457c0497d87bf8d160",
+    "zh:930e3ae3d0cb152e17ee5a8aee5cb47f7613d6421bc7c22e7f50c19da484a100",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a19bf49b80101a0f0272b994153eeff8f8c206ecc592707bfbce7563355b6882",
+    "zh:a34b5d2bbaf52285b0c9a8df6258f4789f4d927ff777e126bdc77e7887abbeaa",
+    "zh:caad6fd5e79eae33e6d74e38c3b15c28a5482f2a1a8ca46cc1ee70089de61adb",
+    "zh:f2eae988635030de9a088f8058fbcd91e2014a8312a48b16bfd09a9d69d9d6f7",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.1.1"
+  constraints = ">= 2.1.0"
+  hashes = [
+    "h1:71sNUDvmiJcijsvfXpiLCz0lXIBSsEJjMxljt7hxMhw=",
+    "h1:Pctug/s/2Hg5FJqjYcTM0kPyx3AoYK1MpRWO0T9V2ns=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}

--- a/.infra/non-prod/ap-southeast-2/uat/hypractive-clockify-api-client/readme.md
+++ b/.infra/non-prod/ap-southeast-2/uat/hypractive-clockify-api-client/readme.md
@@ -1,0 +1,20 @@
+# Lambda application provisioning
+
+Before provisioning this Lambda application, you'll need to run the CI/CD pipeline to upload builds to the artifactory.
+
+- The build's name of the application should be: `hypractive-clockify-api-client-application-artifact.zip`
+- The build's name of the layer should be: `hypractive-clockify-api-client-layer-artifact.zip`
+
+The artifactory S3 bucket's name is `hypractive-clockify-api-client-artifactory`.
+
+## Create the Lambda application
+
+```terragrunt
+aws-vault exec hypr-nonprod-infraadmin -- terragrunt apply
+```
+
+## Destroy the Lambda application
+
+```terragrunt
+aws-vault exec hypr-nonprod-infraadmin -- terragrunt destroy
+```

--- a/.infra/non-prod/ap-southeast-2/uat/hypractive-clockify-api-client/terragrunt.hcl
+++ b/.infra/non-prod/ap-southeast-2/uat/hypractive-clockify-api-client/terragrunt.hcl
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform that supports locking and enforces best
+# practices: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
+
+
+
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+terraform {
+  source = "git@github.com:hyprnz/hypr-terraform-modules.git//lambda/application?ref=v0.5.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = "${find_in_parent_folders()}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+# ---------------------------------------------------------------------------------------------------------------------
+inputs = {
+  application_runtime = "nodejs16.x"
+  application_version = "0.0.1"
+  application_env_vars = {
+    API_KEY = "TODO: need to set grab this from ssm params"
+    WORKSPACE_ID = "62f2e35cb231d8663504739d" # HyprActive Mock
+  }
+  create_dynamodb_table = true
+  dynamodb_table_name   = "hypractive-clockify-api-client-uat"
+  dynamodb_hash_key     = "id"
+}

--- a/.infra/prod/account.yaml
+++ b/.infra/prod/account.yaml
@@ -1,0 +1,1 @@
+aws_account_number: 191708792900

--- a/.infra/prod/ap-southeast-2/prod/environment.yaml
+++ b/.infra/prod/ap-southeast-2/prod/environment.yaml
@@ -1,0 +1,1 @@
+environment: prod

--- a/.infra/prod/ap-southeast-2/prod/hypractive-staff-service/.terraform.lock.hcl
+++ b/.infra/prod/ap-southeast-2/prod/hypractive-staff-service/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.29.0"
+  constraints = ">= 3.38.0"
+  hashes = [
+    "h1:cpTUwXfdtmmUqsnYwXFQ5gZjnfz5cgvydmcGxrv+BeA=",
+    "zh:091615c6dddd556b8cc1cd54e1c5c1fe71b593acebacd0b274a2fed7fc4ca802",
+    "zh:4cc11d7252813b2d7cb52e78b24af8eaf377cc242d1d672a7f8bf680758a4976",
+    "zh:565f46308d6e96a21c273e84e0f73d3f39fd8159fc5aaf41bf65c0b0dd6f1de3",
+    "zh:627b6a5574262b5f07c0e012bcb5c73afd97d90b75389c0ab154b5ae4c0dce8f",
+    "zh:91622572d311c28504fbf14e9364120fbafb3adf8e2d49bfdf014752dac9dac0",
+    "zh:98f37f07628b7c2960335b772a544de6bb90f0f390b9d5fdcc3ac211b9cd7def",
+    "zh:9a6338478ba0e7ca75c5b43e0f91dde12d17273b1dc9934c8ff4d631b8bb837a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a1cc1fc49e406cba1e98250bc04a47be0b6babf5bb42f23baa40f2dc7f8b90f7",
+    "zh:a251e933412036426e2f7b090000c198feee114270d5724bcc8dd9d674d43689",
+    "zh:b0ef3b92947cc8cea75634139dfbfcae2207a9cb5c31d827cd34e523ca04e919",
+    "zh:fb9ede02c9291e7677877bc21ec5c094da38e3cd44df91da5af36f504be399be",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.1.1"
+  constraints = ">= 2.1.0"
+  hashes = [
+    "h1:71sNUDvmiJcijsvfXpiLCz0lXIBSsEJjMxljt7hxMhw=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}

--- a/.infra/prod/ap-southeast-2/prod/hypractive-staff-service/readme.md
+++ b/.infra/prod/ap-southeast-2/prod/hypractive-staff-service/readme.md
@@ -1,0 +1,20 @@
+# Lambda application provisioning
+
+Before provisioning this Lambda application, you'll need to run the CI/CD pipeline to upload builds to the artifactory.
+
+- The build's name of the application should be: `hypractive-clockify-api-client-application-artifact.zip`
+- The build's name of the layer should be: `hypractive-clockify-api-client-layer-artifact.zip`
+
+The artifactory S3 bucket's name is `hypractive-clockify-api-client-artifactory`.
+
+## Create the Lambda application
+
+```terragrunt
+aws-vault exec hypr-prod-infraadmin -- terragrunt apply
+```
+
+## Destroy the Lambda application
+
+```terragrunt
+aws-vault exec hypr-prod-infraadmin -- terragrunt destroy
+```

--- a/.infra/prod/ap-southeast-2/prod/hypractive-staff-service/terragrunt.hcl
+++ b/.infra/prod/ap-southeast-2/prod/hypractive-staff-service/terragrunt.hcl
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform that supports locking and enforces best
+# practices: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
+
+
+
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+terraform {
+  source = "git@github.com:hyprnz/hypr-terraform-modules.git//lambda/application?ref=v0.5.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = "${find_in_parent_folders()}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+# ---------------------------------------------------------------------------------------------------------------------
+inputs = {
+  application_runtime = "nodejs16.x"
+  application_version = "0.0.1"
+  application_env_vars = {
+    API_KEY = "TODO: need to set grab this from ssm params"
+    WORKSPACE_ID = "605a5bfe2ee8a33c7713614d"; # HYPR Innovation
+  }
+  create_dynamodb_table = true
+  dynamodb_table_name   = "hypractive-clockify-api-client-prod"
+  dynamodb_hash_key     = "id"
+}

--- a/.infra/prod/ap-southeast-2/region.yaml
+++ b/.infra/prod/ap-southeast-2/region.yaml
@@ -1,0 +1,1 @@
+aws_region: ap-southeast-2

--- a/.infra/terragrunt.hcl
+++ b/.infra/terragrunt.hcl
@@ -1,0 +1,50 @@
+remote_state {
+  backend = "s3"
+  config = {
+    bucket         = "admin-terraform-state.hypr.nz"
+    key            = "accounts/${path_relative_to_include()}/terraform.tfstate"
+    region         = "ap-southeast-2"
+    role_arn       = "arn:aws:iam::107484634957:role/TerragruntAdministrator"
+    encrypt        = true
+    dynamodb_table = "admin-terraform-lock"
+    s3_bucket_tags = {
+      owner = "terragrunt"
+      name  = "Terraform state storage"
+    }
+    dynamodb_table_tags = {
+      owner = "terragrunt"
+      name  = "Terraform lock table"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# GLOBAL PARAMETERS
+# These variables apply to all configurations in this subfolder. These are automatically merged into the child
+# `terragrunt.hcl` config via the include block.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  default_yaml_path = find_in_parent_folders("empty.yaml")
+}
+
+# Configure root level variables that all resources can inherit. This is especially helpful with multi-account configs
+# where terraform_remote_state data sources are placed directly into the modules.
+inputs = merge(
+  # Configure Terragrunt to use common vars encoded as yaml to help you keep often-repeated variables (e.g., account ID)
+  # DRY. We use yamldecode to merge the maps into the inputs, as opposed to using varfiles due to a restriction in
+  # Terraform >=0.12 that all vars must be defined as variable blocks in modules. Terragrunt inputs are not affected by
+  # this restriction.
+  yamldecode(
+    file(find_in_parent_folders("hypractive.yaml", local.default_yaml_path)),
+  ),
+  yamldecode(
+    file(find_in_parent_folders("account.yaml", local.default_yaml_path)),
+  ),
+  yamldecode(
+    file(find_in_parent_folders("region.yaml", local.default_yaml_path)),
+  ),
+  yamldecode(
+    file(find_in_parent_folders("environment.yaml", local.default_yaml_path)),
+  ),
+)


### PR DESCRIPTION
WIP of infra for clockify API client

TODO:
- [ ] Store clockify API keys securely (encrypted in source? manually in SSM?)
- [ ] Create S3 bucket so that when the client runs, it has somewhere to dump the clockify API response JSON data
- [ ] Configure the lambda in `hypractive.yaml` with correct values (current values are just examples)
- [ ] Configure the lambda in `hypractive.yaml` to run on a CRON schedule to generate daily detailed report data
- [ ] Run infra as part of the GH Actions pipeline